### PR TITLE
Allow for logging to be in its own section in dashboard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ const defaultOptions = {
   formatter: 'stylish',
 }
 
+let logger;
+
 const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions) => {
   const opts = { ...defaultOptions, ...pluginOptions }
   const eslint = new ESLint(opts.options)
@@ -33,13 +35,18 @@ const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions) => {
     const resultText = formatter.format(lintResult)
 
     if (opts.options.fix && lintResult) ESLint.outputFixes(lintResult)
-
-    console.log(resultText)
+    
+    if(resultText.length === 0){
+      log('WORKER_MSG', {msg: `No lint errors found.`})
+    } else {
+      log('WORKER_MSG', {msg: resultText})
+    }
   }
 
   return {
     name: '@canarise/snowpack-eslint-plugin',
-    run() {
+    run({log}) {
+      logger = log;
       return runLint()
     },
     onChange() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions): Plugin
       return runLint()
     },
     onChange() {
+      logger('WORKER_RESET', {});
       return runLint()
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { SnowpackPluginFactory } from 'snowpack'
+import type { SnowpackPluginFactory, PluginRunOptions } from 'snowpack'
 
 import { ESLint } from 'eslint'
 
@@ -18,14 +18,14 @@ const defaultOptions = {
   formatter: 'stylish',
 }
 
-let logger: (s: string, { msg }: { msg: string }) => void;
-
+type Logger = (s: string, { msg }: { msg: string }) => void;
 interface PluginFactory extends ReturnType<SnowpackPluginFactory> {
-  run({ isDev, log } : {
-    isDev: boolean,
-    log: (s: string, { msg }: { msg: string }) => void,
+  run({ isDev, log } : PluginRunOptions & {
+    log: Logger,
   }): Promise<unknown>
 }
+
+let logger: Logger;
 
 const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions): PluginFactory => {
   const opts = { ...defaultOptions, ...pluginOptions }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,16 +11,23 @@ type PluginOptions = {
 const defaultOptions = {
   options: {
     cache: true,
-    cacheStrategy: 'content',
+    cacheStrategy: 'content' as 'content',
     fix: false,
   },
   globs: [],
   formatter: 'stylish',
 }
 
-let logger;
+let logger: (s: string, { msg }: { msg: string }) => void;
 
-const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions) => {
+interface PluginFactory extends ReturnType<SnowpackPluginFactory> {
+  run({ isDev, log } : {
+    isDev: boolean,
+    log: (s: string, { msg }: { msg: string }) => void,
+  }): Promise<unknown>
+}
+
+const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions): PluginFactory => {
   const opts = { ...defaultOptions, ...pluginOptions }
   const eslint = new ESLint(opts.options)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,9 @@ const plugin: SnowpackPluginFactory = (_, pluginOptions?: PluginOptions) => {
     if (opts.options.fix && lintResult) ESLint.outputFixes(lintResult)
     
     if(resultText.length === 0){
-      log('WORKER_MSG', {msg: `No lint errors found.`})
+      logger('WORKER_MSG', {msg: `No lint errors found.`})
     } else {
-      log('WORKER_MSG', {msg: resultText})
+      logger('WORKER_MSG', {msg: resultText})
     }
   }
 


### PR DESCRIPTION
Moved to using snowpack worker log instead of console.log.
This allows the plugin to be in it's own section in the debugger instead of printing to the snowpack console.log.

Also fixes type errors.

Example with no errors:
![image](https://user-images.githubusercontent.com/1948935/144697138-1bf7c225-94b4-41e1-8b0f-8f99d1f1686c.png)


Example with errors:
![image](https://user-images.githubusercontent.com/1948935/144697127-177a6501-8f84-446b-9499-00888759f68b.png)
